### PR TITLE
Fix issue #23 - ChallengesToDo shows wrong number.

### DIFF
--- a/src/main/java/bentobox/addon/challenges/panel/ChallengesPanels.java
+++ b/src/main/java/bentobox/addon/challenges/panel/ChallengesPanels.java
@@ -112,10 +112,14 @@ public class ChallengesPanels {
     }
 
     private void addNavigation(PanelBuilder panelBuilder) {
+        // TODO: This if fix for wrong getNumberOfChallengesStillToDo() issue. #23
+        LevelStatus previousStatus = null;
+
         // Add navigation to other levels
         for (LevelStatus status: manager.getChallengeLevelStatus(user, world)) {
             if (status.getLevel().getUniqueId().equals(level)) {
                 // Skip if this is the current level
+                previousStatus = status;
                 continue;
             }
             // Create a nice name for the level
@@ -140,10 +144,12 @@ public class ChallengesPanels {
                 PanelItem item = new PanelItemBuilder()
                         .icon(new ItemStack(Material.BOOK))
                         .name(name)
-                        .description(manager.stringSplit(user.getTranslation("challenges.to-complete", "[challengesToDo]",String.valueOf(status.getNumberOfChallengesStillToDo()), "[thisLevel]", previousLevelName)))
+                        .description(manager.stringSplit(user.getTranslation("challenges.to-complete", "[challengesToDo]",String.valueOf(previousStatus != null ? previousStatus.getNumberOfChallengesStillToDo() : ""), "[thisLevel]", previousLevelName)))
                         .build();
                 panelBuilder.item(item);
             }
+
+            previousStatus = status;
         }
     }
 

--- a/src/main/java/bentobox/addon/challenges/panel/ChallengesPanels2.java
+++ b/src/main/java/bentobox/addon/challenges/panel/ChallengesPanels2.java
@@ -167,10 +167,14 @@ public class ChallengesPanels2 {
     }
 
     private void addNavigation(PanelBuilder panelBuilder) {
+        // TODO: This if fix for wrong getNumberOfChallengesStillToDo() issue. #23
+        LevelStatus previousStatus = null;
+
         // Add navigation to other levels
         for (LevelStatus status: manager.getChallengeLevelStatus(requester, world)) {
             if (status.getLevel().getUniqueId().equalsIgnoreCase(level)) {
                 // Skip if this is the current level
+                previousStatus = status;
                 continue;
             }
             // Create a nice name for the level
@@ -195,10 +199,12 @@ public class ChallengesPanels2 {
                 PanelItem item = new PanelItemBuilder()
                         .icon(new ItemStack(Material.BOOK))
                         .name(name)
-                        .description(manager.stringSplit(requester.getTranslation("challenges.to-complete", "[challengesToDo]",String.valueOf(status.getNumberOfChallengesStillToDo()), "[thisLevel]", previousLevelName)))
+                        .description(manager.stringSplit(requester.getTranslation("challenges.to-complete", "[challengesToDo]",String.valueOf(previousStatus != null ? previousStatus.getNumberOfChallengesStillToDo() : ""), "[thisLevel]", previousLevelName)))
                         .build();
                 panelBuilder.item(item);
             }
+
+            previousStatus = status;
         }
     }
 


### PR DESCRIPTION
This issue happens, because LevelStatus keeps record about current level completion. So "novice" level knows how much it needs to unlock the next level and so on.
My proposed fix is just workaround of current behavior, but I think there is necessary better rework of LevelStatus object.
