### PR TITLE
Implement AutoSaving

### DIFF
--- a/src/main/java/bentobox/addon/challenges/ChallengesAddon.java
+++ b/src/main/java/bentobox/addon/challenges/ChallengesAddon.java
@@ -5,6 +5,7 @@ import org.bukkit.Bukkit;
 import bentobox.addon.challenges.commands.ChallengesCommand;
 import bentobox.addon.challenges.commands.admin.Challenges;
 import bentobox.addon.challenges.listeners.ResetListener;
+import bentobox.addon.challenges.listeners.SaveListener;
 import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 
@@ -73,6 +74,8 @@ public class ChallengesAddon extends Addon {
         }
         // Register the reset listener
         this.registerListener(new ResetListener(this));
+        // Register the autosave listener.
+        this.registerListener(new SaveListener(this));
         // Done
     }
 

--- a/src/main/java/bentobox/addon/challenges/listeners/SaveListener.java
+++ b/src/main/java/bentobox/addon/challenges/listeners/SaveListener.java
@@ -1,0 +1,36 @@
+package bentobox.addon.challenges.listeners;
+
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.WorldSaveEvent;
+
+import bentobox.addon.challenges.ChallengesAddon;
+
+
+/**
+ * This is Simple World Save event listener. On each world save, this method
+ * asks challenge manager to save its data.
+ */
+public class SaveListener implements Listener
+{
+	public SaveListener(ChallengesAddon addon) {
+		this.addon = addon;
+	}
+
+
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	public void onWorldSave(WorldSaveEvent e)
+	{
+		this.addon.getChallengesManager().save(e.isAsynchronous());
+	}
+
+
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
+
+
+	private ChallengesAddon addon;
+}

--- a/src/main/java/bentobox/addon/challenges/listeners/SaveListener.java
+++ b/src/main/java/bentobox/addon/challenges/listeners/SaveListener.java
@@ -23,7 +23,10 @@ public class SaveListener implements Listener
 	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onWorldSave(WorldSaveEvent e)
 	{
-		this.addon.getChallengesManager().save(e.isAsynchronous());
+		if (!this.addon.getChallengesManager().getAllChallengesList(e.getWorld()).isEmpty())
+		{
+			this.addon.getChallengesManager().save(e.isAsynchronous());
+		}
 	}
 
 


### PR DESCRIPTION
Add a new listener for WorldSaveEvent that will save challenges for the world, in which event was called.
This should improve situations, when challenges are not stored if server crashes, as now they will be regularly stored.
This should fix issue #21